### PR TITLE
Fixed yml syntax for links

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,9 +3,9 @@ name: RStudio Server
 category: Interactive Apps
 subcategory: Servers
 role: batch_connect
-description: "This app will launch [RStudio Server] an IDE for [R] on the Habrok cluster.
+description: "This app will launch [RStudio Server], an IDE for [R] on the Habrok cluster.\r\n
 
-  [RStudio Server]: https://www.rstudio.com/products/rstudio-server/
+  [RStudio Server]: https://www.rstudio.com/products/rstudio-server/\r\n
   [R]: https://www.r-project.org/"
 version: 0.1
 icon: ''


### PR DESCRIPTION
The syntax to include links in the form has been fixed in `manifest.yml`.