### PR TITLE
Added R 4.3.2

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -36,7 +36,7 @@ attributes:
 
   version:
     widget: "select"
-    label: "RStudio version"
+    label: "R version"
     help: |
       Select one of the RStudio versions from the dropdown.
     options:

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -49,6 +49,15 @@ attributes:
             data-option-for-node-type-himem: false, 
             data-option-for-node-type-gelifes: false
         ]
+      - [   "R 4.3.2","RStudio-Server/2023.12.1+402-gfbf-2023a-Java-11-R-4.3.2",
+            data-option-for-node-type-gpua100: false,
+            data-option-for-node-type-gpuv100: false
+        ]
+      - [   "R 4.3.2 (GPU)","RStudio-Server/2023.12.1+402-gfbf-2023a-Java-11-R-4.3.2 CUDA/11.7.0",
+            data-option-for-node-type-regular: false, 
+            data-option-for-node-type-himem: false, 
+            data-option-for-node-type-gelifes: false
+        ]
 
   num_hours:
     label: Number of hours


### PR DESCRIPTION
Added version R 4.3.2. This solves the Jira ticket HC-700. Can be tested on `portaltest.hb.hpc.rug.nl`, reachable from the Safenet VPN (and eduroam), for both the GPU and non-GPU nodes.