### PR TITLE
Use `python3` instead of `python`

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -41,7 +41,7 @@ cd "${HOME}"
 export TMPDIR="$(mktemp -d)"
   
 mkdir -p "$TMPDIR/rstudio-server"
-python -c 'from uuid import uuid4; print(uuid4())' > "$TMPDIR/rstudio-server/secure-cookie-key"
+python3 -c 'from uuid import uuid4; print(uuid4())' > "$TMPDIR/rstudio-server/secure-cookie-key"
 chmod 0600 "$TMPDIR/rstudio-server/secure-cookie-key"
   
 export DATABASE_CONFIG_FILE="${TMPDIR}/rstudio-server/database.config"


### PR DESCRIPTION
Just saw this when I was inspecting the output file of an RStudio session:
```
/home1/p251204/ondemand/data/sys/dashboard/batch_connect/sys/hb-rstudio_server/output/8e912cbe-bf3b-4790-8e82-12a51ec0809b/script.sh: line 44: python: command not found
```

The nodes don't have a `python` executable, but there is `python3`, so it can be easily fixed.