### PR TITLE
Load Bioconductor bundle by default on R 4.3.2 (to add Seurat)

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -49,11 +49,11 @@ attributes:
             data-option-for-node-type-himem: false, 
             data-option-for-node-type-gelifes: false
         ]
-      - [   "R 4.3.2","RStudio-Server/2023.12.1+402-gfbf-2023a-Java-11-R-4.3.2 Seurat/5.0.1-foss-2023a-R-4.3.2",
+      - [   "R 4.3.2","RStudio-Server/2023.12.1+402-gfbf-2023a-Java-11-R-4.3.2 R-bundle-Bioconductor/3.18-foss-2023a-R-4.3.2",
             data-option-for-node-type-gpua100: false,
             data-option-for-node-type-gpuv100: false
         ]
-      - [   "R 4.3.2 (GPU)","RStudio-Server/2023.12.1+402-gfbf-2023a-Java-11-R-4.3.2 CUDA/11.7.0 Seurat/5.0.1-foss-2023a-R-4.3.2",
+      - [   "R 4.3.2 (GPU)","RStudio-Server/2023.12.1+402-gfbf-2023a-Java-11-R-4.3.2 CUDA/11.7.0 R-bundle-Bioconductor/3.18-foss-2023a-R-4.3.2",
             data-option-for-node-type-regular: false, 
             data-option-for-node-type-himem: false, 
             data-option-for-node-type-gelifes: false

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -49,11 +49,11 @@ attributes:
             data-option-for-node-type-himem: false, 
             data-option-for-node-type-gelifes: false
         ]
-      - [   "R 4.3.2","RStudio-Server/2023.12.1+402-gfbf-2023a-Java-11-R-4.3.2",
+      - [   "R 4.3.2","RStudio-Server/2023.12.1+402-gfbf-2023a-Java-11-R-4.3.2 Seurat/5.0.1-foss-2023a-R-4.3.2",
             data-option-for-node-type-gpua100: false,
             data-option-for-node-type-gpuv100: false
         ]
-      - [   "R 4.3.2 (GPU)","RStudio-Server/2023.12.1+402-gfbf-2023a-Java-11-R-4.3.2 CUDA/11.7.0",
+      - [   "R 4.3.2 (GPU)","RStudio-Server/2023.12.1+402-gfbf-2023a-Java-11-R-4.3.2 CUDA/11.7.0 Seurat/5.0.1-foss-2023a-R-4.3.2",
             data-option-for-node-type-regular: false, 
             data-option-for-node-type-himem: false, 
             data-option-for-node-type-gelifes: false

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -26,6 +26,17 @@ sed 's/^ \{2\}//' > "${RSESSION_WRAPPER_FILE}" << EOL
   export RSESSION_LOG_FILE="${WORKING_DIR}/rsession.log"
   
   exec &>>"\${RSESSION_LOG_FILE}"
+
+  # rsession.sh doesn't share the same env as the outside script, so these
+  # need to be set explicitly
+  # All variables related to R libraries, underlying binary libraries
+  # and building on top of these have to be included.
+  export R_LIBS_SITE="${R_LIBS_SITE}"
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}"
+  export LIBRARY_PATH="${LIBRARY_PATH}"
+  export CPATH="${CPATH}"
+  export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}"
+  export PYTHONPATH="${PYTHONPATH}"
   
   # Launch the original command
   echo "Launching rsession..."


### PR DESCRIPTION
To add the Seurat package, and potential other packages users may want, we now explicitly load the R Bioconductor bundle when starting up the RStudio portal app.